### PR TITLE
Fixing the month display

### DIFF
--- a/internals/models/global.go
+++ b/internals/models/global.go
@@ -66,6 +66,7 @@ type Day struct {
 	DayName   string
 	DayDate   time.Time
 	DayEvents []Event
+	Empty     bool
 }
 
 // Create an event struct to store the event data

--- a/template/month.tpl
+++ b/template/month.tpl
@@ -129,8 +129,13 @@
           <th
             class="text-gray-600 font-normal text-sm py-2 px-2 border-b border-gray-200"
           >
+            {{ if .Empty }}
+            <!-- If the day is empty, display nothing in the header -->
+            &nbsp;
+            {{ else }}
             {{ .DayName }}
-          </th> 
+            {{ end }}
+          </th>
           {{ end }}
         </tr>
       </thead>


### PR DESCRIPTION
Bug where if the last week was overlapping into the next month, the days name of the next month where not displayed correctly